### PR TITLE
Rename reserved names and add historyPreserveItems to PluginSpec.t

### DIFF
--- a/src/PM_Decoration.re
+++ b/src/PM_Decoration.re
@@ -9,7 +9,7 @@ type spec = Js.Dict.t(string);
 [@bs.deriving abstract]
 type t = {
   from: int,
-  to_: int,
+  [@bs.as "to"] to_: int,
   spec,
 };
 

--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -242,7 +242,7 @@ module ContentMatch = {
     t =>
     {
       .
-      "type_": Types.nodeType,
+      "_type": Types.nodeType,
       "next": t,
     } =
     "edge";

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -422,7 +422,7 @@ module ContentMatch: {
     t =>
     {
       .
-      "type_": PM_Types.nodeType,
+      "_type": PM_Types.nodeType,
       "next": t,
     };
 };

--- a/src/PM_State.re
+++ b/src/PM_State.re
@@ -350,6 +350,8 @@ module PluginSpec = {
         ~newState: Types.editorState
       ) =>
       Js.Nullable.t(Types.transaction),
+    [@bs.optional]
+    historyPreserveItems: bool
   };
 
   let make = t;

--- a/src/PM_State.rei
+++ b/src/PM_State.rei
@@ -520,6 +520,10 @@ module PluginSpec: {
     transactions. When another plugin appends a transaction after this was called, it is called
     again with the new state and new transactions—but only the new transactions, i.e. it won't be
     passed transactions that it already saw.
+
+    [historyPreserveItems] This is used to notify the history plugin to not merge steps,
+    so that the history can be rebased.
+    Used in the collab plugin for example
    */
   let make:
     (
@@ -535,6 +539,7 @@ module PluginSpec: {
                           ) =>
                           Js.Nullable.t(PM_Types.transaction)
                             =?,
+      ~historyPreserveItems: bool=?,
       unit
     ) =>
     t('a);

--- a/src/PM_Transform.re
+++ b/src/PM_Transform.re
@@ -212,7 +212,7 @@ module Transform = {
         ~range: Model.NodeRange.t,
         ~wrappers: array({
                      .
-                     "type_": Model.NodeType.t,
+                     "_type": Model.NodeType.t,
                      "attrs": Model.Attrs.t,
                    })
       ) =>
@@ -236,7 +236,7 @@ module Transform = {
         ~depth: int=?,
         ~typesAfter: array({
                        .
-                       "type_": Model.NodeType.t,
+                       "_type": Model.NodeType.t,
                        "attrs": Model.Attrs.t,
                      })
                        =?,
@@ -265,7 +265,7 @@ possible.
       option(
         array({
           .
-          "type_": Model.NodeType.t,
+          "_type": Model.NodeType.t,
           "attrs": Model.Attrs.t,
         }),
       );
@@ -276,7 +276,7 @@ possible.
         ~depth: int=?,
         ~typesAfter: array({
                        .
-                       "type_": Model.NodeType.t,
+                       "_type": Model.NodeType.t,
                        "attrs": Model.Attrs.t,
                      })
                        =?
@@ -363,7 +363,7 @@ possible.
         ~range: Model.NodeRange.t,
         ~wrappers: array({
                      .
-                     "type_": Model.NodeType.t,
+                     "_type": Model.NodeType.t,
                      "attrs": Model.Attrs.t,
                    })
       ) =>
@@ -393,7 +393,7 @@ possible.
         ~depth: int=?,
         ~typesAfter: array({
                        .
-                       "type_": Model.NodeType.t,
+                       "_type": Model.NodeType.t,
                        "attrs": Model.Attrs.t,
                      })
                        =?,
@@ -425,7 +425,7 @@ possible.
       option(
         array({
           .
-          "type_": Model.NodeType.t,
+          "_type": Model.NodeType.t,
           "attrs": Model.Attrs.t,
         }),
       ) =
@@ -438,7 +438,7 @@ possible.
         ~depth: int=?,
         ~typesAfter: array({
                        .
-                       "type_": Model.NodeType.t,
+                       "_type": Model.NodeType.t,
                        "attrs": Model.Attrs.t,
                      })
                        =?

--- a/src/PM_Transform.rei
+++ b/src/PM_Transform.rei
@@ -504,7 +504,7 @@ module Transform: {
         ~wrappers: array({
                      .
                      "attrs": PM_Model.Attrs.t,
-                     "type_": PM_Model.NodeType.t,
+                     "_type": PM_Model.NodeType.t,
                    })
       ) =>
       t;
@@ -555,7 +555,7 @@ module Transform: {
         ~typesAfter: array({
                        .
                        "attrs": PM_Model.Attrs.t,
-                       "type_": PM_Model.NodeType.t,
+                       "_type": PM_Model.NodeType.t,
                      })
                        =?,
         unit
@@ -608,7 +608,7 @@ module Transform: {
         array({
           .
           "attrs": PM_Model.Attrs.t,
-          "type_": PM_Model.NodeType.t,
+          "_type": PM_Model.NodeType.t,
         }),
       );
 
@@ -624,7 +624,7 @@ module Transform: {
         ~typesAfter: array({
                        .
                        "attrs": PM_Model.Attrs.t,
-                       "type_": PM_Model.NodeType.t,
+                       "_type": PM_Model.NodeType.t,
                      })
                        =?
       ) =>


### PR DESCRIPTION
Because of a wrong fix in one of my PR, some Js.t incorrectly used `type_` instead of `_type` for a field called `type` in JS (reserved word in Reason) in PM_Model and PM_Transform.
There was also an abstract type using a `to_` field that lacked the the `[@bs.as "to"]`
I also added a field in PluginSpec.t called historyPreserveItems that is not in the docs but which is used by plugins working with history. If we encounter more use cases for extra fields in PluginSpec.t maybe we could add an `options` field of type `Js.t` for such cases.