### PR TITLE
Model: Add `Text` to DOMOutputSpec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-prosemirror",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -15,6 +15,7 @@ module DOMOutputSpec = {
   type spec =
     | LeafNode(string, Attrs.t): spec
     | Node(string, Attrs.t, spec): spec
+    | Text(string): spec
     | Hole: spec;
   type t;
   let fromString: string => t = a => Obj.magic(a);
@@ -26,6 +27,7 @@ module DOMOutputSpec = {
           switch (a) {
           | LeafNode(str, obj) => (str, obj) |> Obj.magic
           | Hole => Obj.magic(0)
+          | Text(text) => Obj.magic(text)
           | Node(str, obj, y) => (str, obj, run(y)) |> Obj.magic
           };
       run(a);

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -32,6 +32,7 @@ module DOMOutputSpec: {
   type spec =
     | LeafNode(string, Attrs.t): spec
     | Node(string, Attrs.t, spec): spec
+    | Text(string): spec
     | Hole: spec;
 
   type t;


### PR DESCRIPTION
The DOMOutputSpec was missing the ability to use `text`. This pull request adds that functionality.