### PR TITLE
Add view as this

### DIFF
--- a/example/Index.re
+++ b/example/Index.re
@@ -41,7 +41,18 @@ let config =
 
 let state = EditorState.create(config);
 
-let viewConfig = PM.View.DirectEditorProps.t(~state, ());
+let viewConfig =
+  PM.View.DirectEditorProps.make(
+    ~state,
+    ~dispatchTransaction=
+      (view, tr) => {
+        Js.log2("tr", tr);
+        let oldState = view->PM.View.state;
+        let newState = oldState->PM.State.EditorState.apply(tr);
+        PM.View.updateState(view, newState);
+      },
+    (),
+  );
 
 let editorNode = {
   Webapi.(Dom.Document.getElementById("editor", Dom.document)->Belt.Option.getExn);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-prosemirror",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Reason/Bucklescript bindings for ProseMirror",
   "scripts": {
     "build": "bsb -make-world",


### PR DESCRIPTION
This change is required to support view instance as the first argument
to `dispatchTransaction` without being forced to pass the function
annotated with `[@bs.this]`.