### PR TITLE
Use different types for Step subclasses

### DIFF
--- a/src/PM_State.rei
+++ b/src/PM_State.rei
@@ -41,6 +41,18 @@ module SelectionKind: {
   let nodeSelectionToSelection: PM_Types.nodeSelection => PM_Types.selection;
   let textSelectionToSelection: PM_Types.textSelection => PM_Types.selection;
   let allSelectionToSelection: PM_Types.allSelection => PM_Types.selection;
+  type t = [
+    | `NodeSelection(PM_Types.nodeSelection)
+    | `TextSelection(PM_Types.textSelection)
+    | `AllSelection(PM_Types.allSelection)
+    ];
+  let classify:
+      (
+        PM_Types.selection,
+        ~custom: (PM_Types.selection, string) => option(([> t] as 'a))=?,
+        unit,
+      )
+      => ([> t] as 'a);
 };
 
 /** A ProseMirror selection can be one of several types. This module defines
@@ -220,6 +232,13 @@ module Selection: {
   let fromNodeSelection: PM_Types.nodeSelection => PM_Types.selection;
   let fromTextSelection: PM_Types.textSelection => PM_Types.selection;
   let fromAllSelection: PM_Types.allSelection => PM_Types.selection;
+  let classify:
+    (
+      PM_Types.selection,
+      ~custom: (PM_Types.selection, string) => option(([> SelectionKind.t] as 'a))=?,
+      unit,
+    )
+    => ([> SelectionKind.t] as 'a);
 };
 
 /** A text selection represents a classical editor selection, with a head (the moving side) and

--- a/src/PM_Types.re
+++ b/src/PM_Types.re
@@ -15,3 +15,8 @@ type editorState;
 type plugin;
 type editorView;
 type decorationSet;
+type step;
+type replaceStep;
+type replaceAroundStep;
+type addMarkStep;
+type removeMarkStep;


### PR DESCRIPTION
This PR adds different types to `PM.Transform.Step` subclasses in the same way we did for `PM.State.Selection` subclasses.
This allows to add bindings to `PM.Transform.Step` subclasses property accessors.
It also adds a `classify` function that allows to  cast a `PM.Transform.Step.t` to its actual subclass, and its equivalent for `PM.State.Selection.t`.
