### PR TITLE
Add a function to cast Step subclasses to Step.t

### DIFF
--- a/src/PM_State.rei
+++ b/src/PM_State.rei
@@ -46,13 +46,13 @@ module SelectionKind: {
     | `TextSelection(PM_Types.textSelection)
     | `AllSelection(PM_Types.allSelection)
     ];
-  let classify:
-      (
-        PM_Types.selection,
-        ~custom: (PM_Types.selection, string) => option(([> t] as 'a))=?,
-        unit,
-      )
-      => ([> t] as 'a);
+  let classify: PM_Types.selection => t;
+  let classifyCustom:
+    (
+      PM_Types.selection,
+      ~custom: (PM_Types.selection, string) => option([> t] as 'a)
+    ) =>
+    ([> t] as 'a);
 };
 
 /** A ProseMirror selection can be one of several types. This module defines
@@ -232,13 +232,14 @@ module Selection: {
   let fromNodeSelection: PM_Types.nodeSelection => PM_Types.selection;
   let fromTextSelection: PM_Types.textSelection => PM_Types.selection;
   let fromAllSelection: PM_Types.allSelection => PM_Types.selection;
-  let classify:
+  let classify: PM_Types.selection => SelectionKind.t;
+  let classifyCustom:
     (
       PM_Types.selection,
-      ~custom: (PM_Types.selection, string) => option(([> SelectionKind.t] as 'a))=?,
-      unit,
-    )
-    => ([> SelectionKind.t] as 'a);
+      ~custom: (PM_Types.selection, string) =>
+               option([> SelectionKind.t] as 'a)
+    ) =>
+    ([> SelectionKind.t] as 'a);
 };
 
 /** A text selection represents a classical editor selection, with a head (the moving side) and

--- a/src/PM_Transform.re
+++ b/src/PM_Transform.re
@@ -126,6 +126,27 @@ module StepKind = {
       | None => failwith("Unknown PM.Transform.Step subclass")
       }
     };
+
+  external replaceStepToStep : Types.replaceStep => Types.step = "%identity";
+  external replaceAroundStepToStep : Types.replaceAroundStep => Types.step = "%identity";
+  external addMarkStepToStep : Types.addMarkStep => Types.step = "%identity";
+  external removeMarkStepToStep : Types.removeMarkStep => Types.step = "%identity";
+
+  let toStep : t => Types.step = fun
+    | `ReplaceStep(step) => step->replaceStepToStep
+    | `ReplaceAroundStep(step) => step->replaceAroundStepToStep
+    | `AddMarkStep(step) => step->addMarkStepToStep
+    | `RemoveMarkStep(step) => step->removeMarkStepToStep;
+
+  let toStepCustom = (~custom: ([>t] as 'a) => Types.step, step : ([>t] as 'a)) =>
+    switch (step) {
+    | (
+        `ReplaceStep(_) | `ReplaceAroundStep(_) | `AddMarkStep(_) |
+        `RemoveMarkStep(_)
+      ) as t =>
+      toStep(t)
+    | other => custom(other)
+    };
 };
 
 module Step = {
@@ -169,11 +190,17 @@ module Step = {
     [@bs.module "prosemirror-transform"] [@bs.scope "Step"]
     external jsonID: (~id: string, ~stepClass: t) => t = "jsonID";
   };
+  module type Subclass = {
+    include T;
+    let toStep: t => Types.step;
+  };
   include Make({
     type nonrec t = t;
     type inverted = t;
   });
   let classify = StepKind.classify;
+  let toStep = StepKind.toStep;
+  let toStepCustom = StepKind.toStepCustom;
 };
 
 module AddMarkStep = {
@@ -183,6 +210,7 @@ module AddMarkStep = {
     type nonrec t = t;
     type nonrec inverted = inverted;
   });
+  let toStep = StepKind.addMarkStepToStep;
   [@bs.module "prosemirror-transform"] [@bs.new]
   external make: (~from: int, ~to_: int, ~mark: Model.Mark.t) => t = "AddMarkStep";
   [@bs.get] external from: t => int = "from";
@@ -197,6 +225,7 @@ module RemoveMarkStep = {
     type nonrec t = t;
     type nonrec inverted = inverted;
   });
+  let toStep = StepKind.removeMarkStepToStep;
   [@bs.module "prosemirror-transform"] [@bs.new]
   external make: (~from: int, ~to_: int, ~mark: Model.Mark.t) => t = "RemoveMarkStep";
   [@bs.get] external from: t => int = "from";
@@ -211,6 +240,7 @@ module ReplaceStep = {
     type nonrec t = t;
     type nonrec inverted = inverted;
   });
+  let toStep = StepKind.replaceStepToStep;
   [@bs.module "prosemirror-transform"] [@bs.new]
   external make: (~from: int, ~to_: int, ~slice: Model.Slice.t, ~structure: bool=?, unit) => t =
     "ReplaceStep";
@@ -227,6 +257,7 @@ module ReplaceAroundStep = {
     type nonrec t = t;
     type nonrec inverted = inverted;
   });
+  let toStep = StepKind.replaceAroundStepToStep;
   [@bs.module "prosemirror-transform"] [@bs.new]
   external make:
     (

--- a/src/PM_Transform.rei
+++ b/src/PM_Transform.rei
@@ -188,11 +188,11 @@ module StepKind: {
     | `RemoveMarkStep(PM_Types.removeMarkStep)
     ];
   
-  let classify:
+  let classify : PM_Types.step => [ t];
+  let classifyCustom:
     (
       PM_Types.step,
-      ~custom: (PM_Types.step, string) => option(([> t] as 'a))=?,
-      unit
+      ~custom: (PM_Types.step, string) => option(([> t] as 'a))
     ) =>
     ([> t] as 'a);
   let replaceStepToStep: PM_Types.replaceStep => PM_Types.step;
@@ -280,11 +280,11 @@ module Step: {
     let toStep: t => PM_Types.step;
   };
   include T with type t := t and type inverted := t;
-  let classify:
+  let classify: PM_Types.step => [ StepKind.t];
+  let classifyCustom:
     (
       PM_Types.step,
-      ~custom: (PM_Types.step, string) => option([> StepKind.t] as 'a)=?,
-      unit
+      ~custom: (PM_Types.step, string) => option([> StepKind.t] as 'a)
     ) =>
     ([> StepKind.t] as 'a);
   let toStep: StepKind.t => PM_Types.step;


### PR DESCRIPTION
Since a lot of functions still need arguments as `Step.t` a function to cast a Step subclass back to `Step.t` was needed.
I also split StepKind.classify and Selection.classify in two to be easier to use especially with partial applications.