### PR TITLE
fix typo in PM.Model.Node.inlinecontent

### DIFF
--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -603,7 +603,7 @@ module Node = {
   external rangeHasMark: (t, ~from: int, ~to_: int, ~type_: MarkType.t) => bool = "rangeHasMark";
   [@bs.get] external isBlock: t => bool = "isBlock";
   [@bs.get] external isTextblock: t => bool = "isTextblock";
-  [@bs.get] external inLineContent: t => bool = "inLineContent";
+  [@bs.get] external inlineContent: t => bool = "inlineContent";
   [@bs.get] external isInline: t => bool = "isInline";
   [@bs.get] external isText: t => bool = "isText";
   [@bs.get] external isLeaf: t => bool = "isLeaf";

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -1258,7 +1258,7 @@ module Node: {
     True when this node allows inline content.
     inlineContent: bool
    */
-  let inLineContent: t => bool;
+  let inlineContent: t => bool;
 
   /** isInline: bool */
   /** True when this is an inline node (a text node or a node that can appear among text). */

--- a/src/PM_State.re
+++ b/src/PM_State.re
@@ -439,6 +439,7 @@ module Transaction = {
   external insertText: (t, ~text: string, ~from: int=?, ~to_: int=?, unit) => t = "insertText";
   [@bs.get] external isGeneric: t => bool = "isGeneric";
   [@bs.send] external scrollIntoView: t => t = "scrollIntoView";
+  [@bs.get] external scrolledIntoView: t => bool = "scrolledIntoView";
 
   module Meta = {
     module type T = {

--- a/src/PM_State.rei
+++ b/src/PM_State.rei
@@ -701,6 +701,13 @@ module Transaction: {
    */
   let scrollIntoView: t => t;
 
+  /**
+    Returns true if the editor should scroll the selection into view
+    when updated to the state produced by this transaction.
+    scrolledIntoView: bool
+   */
+  let scrolledIntoView: t => bool;
+
   module Meta : {
     module type T = {
 


### PR DESCRIPTION
The binding and function were mispelled as inLineContent instead of inlineContent.
I also added a binding to a property called scrolledIntoView in PM.State.Transaction which is not referenced in the docs but that can be useful sometimes.
