### PR TITLE
Fix parameter type for Model.DOMOutputSpec

### DIFF
--- a/example/Index.re
+++ b/example/Index.re
@@ -21,14 +21,14 @@ let config =
             "Mod-b",
             PM.Commands.toggleMark(
               ~markType=schema->Model.Schema.marks->Js.Dict.get("strong")->Option.getExn,
-              ~attrs=Model.Attrs.empty,
+              ~attrs=Model.Attrs.empty(),
             ),
           ),
           (
             "Mod-i",
             PM.Commands.toggleMark(
               ~markType=schema->Model.Schema.marks->Js.Dict.get("em")->Option.getExn,
-              ~attrs=Model.Attrs.empty,
+              ~attrs=Model.Attrs.empty(),
             ),
           ),
         ]

--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -3,7 +3,7 @@ module Attrs = {
   type t;
   let make: Js.t({..}) => t = a => Obj.magic(a);
   let toJs: t => Js.t({..}) = a => Obj.magic(a);
-  let empty = make(Js.Obj.empty());
+  let empty: unit => t = () => make(Js.Obj.empty());
 };
 
 module AttributeSpec = {

--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -11,10 +11,17 @@ module AttributeSpec = {
   [@bs.obj] external make: (~default: 'a=?, unit) => t = "";
 };
 
+module DOMAttrs = {
+  type t = Js.Dict.t(string);
+  let make: Js.Dict.t(string) => t = a => a;
+  let toDict: t => Js.Dict.t(string) = a => a;
+  let empty: unit => t = Js.Dict.empty;
+};
+
 module DOMOutputSpec = {
   type spec =
-    | LeafNode(string, Attrs.t): spec
-    | Node(string, Attrs.t, spec): spec
+    | LeafNode(string, DOMAttrs.t): spec
+    | Node(string, DOMAttrs.t, spec): spec
     | Text(string): spec
     | Hole: spec;
   type t;

--- a/src/PM_Model.re
+++ b/src/PM_Model.re
@@ -490,7 +490,7 @@ module MarkType = {
 };
 
 module SchemaSpec = {
-  [@bs.deriving abstract]
+  [@bs.deriving {abstract: light}]
   type t = {
     nodes: OrderedMap.t(NodeSpec.t),
     marks: OrderedMap.t(MarkSpec.t),

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -2,7 +2,7 @@ module Attrs: {
   type t;
   let make: Js.t({..}) => t;
   let toJs: t => Js.t({..});
-  let empty: t;
+  let empty: unit => t;
 };
 
 module AttributeSpec: {

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -910,14 +910,14 @@ module SchemaSpec: {
      precedence by default, and which nodes come first in a given group.
      nodes: Object<NodeSpec> | OrderedMap<NodeSpec>
    */
-  let nodesGet: t => OrderedMap.t(NodeSpec.t);
+  let nodes: t => OrderedMap.t(NodeSpec.t);
 
   /**
      The mark types that exist in this schema. The order in which they are provided determines the
      order in which mark sets are sorted and in which parse rules are tried.
      marks: ?⁠Object<MarkSpec> | OrderedMap<MarkSpec>
    */
-  let marksGet: t => OrderedMap.t(MarkSpec.t);
+  let marks: t => OrderedMap.t(MarkSpec.t);
 
   /**
      The name of the default top-level node for the schema. Defaults to "doc".

--- a/src/PM_Model.rei
+++ b/src/PM_Model.rei
@@ -17,6 +17,13 @@ module AttributeSpec: {
   let make: (~default: 'a=?, unit) => t;
 };
 
+module DOMAttrs: {
+  type t;
+  let make: Js.Dict.t(string) => t;
+  let toDict: t => Js.Dict.t(string);
+  let empty: unit => t;
+};
+
 module DOMOutputSpec: {
   /**
     A description of a DOM structure. Can be either a string, which is interpreted as a text node,
@@ -30,8 +37,8 @@ module DOMOutputSpec: {
     in its parent node.
    */
   type spec =
-    | LeafNode(string, Attrs.t): spec
-    | Node(string, Attrs.t, spec): spec
+    | LeafNode(string, DOMAttrs.t): spec
+    | Node(string, DOMAttrs.t, spec): spec
     | Text(string): spec
     | Hole: spec;
 


### PR DESCRIPTION
`DOMOutputSpec` attrs are set as DOM node attributes by Prosemirror, they need to be a `Js.Dict.t(string)`.
I created a module for `DOMAttrs` in the same style as `Model.Attrs`, we could also just type `DOMOutputSpec` attrs as `Js.Dict.t(string)` if we want a more straightforward solution.
While at it, I noticed that `Model.Attrs.empty` was a value backed by a mutable object (`Js.t({..})`), a mutation anywhere in the code base would change the value of `Model.Attrs.empty` everywhere. I fixed that by calling the `Js.Obj.empty` function every time but **that changes the signature of `Model.Attrs.empty`**.
I also fixed `Model.SchemaSpec.t` accessors that were mixing "light" and "normal" accessors, a behavior deprecated since BS 4.0 and that will be discontinued starting from BS 7.0 that will be released soon. **That changes the signature of `Model.SchemaSpec`.**